### PR TITLE
Host runbook at `runbook.studentrobotics.org`

### DIFF
--- a/src/domain.tf
+++ b/src/domain.tf
@@ -174,3 +174,10 @@ resource "digitalocean_record" "google-site-verification" {
   type = "TXT"
   value = "9C-IE01HD-UTpvXzlXD1K6hjFnAznMTIjUWk_3P9tL4"
 }
+
+resource "digitalocean_record" "runbook" {
+  domain = "${digitalocean_domain.domain-name.name}"
+  name = "runbook"
+  type = "CNAME"
+  value = "srobo.github.io."
+}


### PR DESCRIPTION
This allows the runbook to be accessed via `runbook.studentrobotics.org`

Partially fixes https://github.com/srobo/runbook/issues/17
Partially fixes https://github.com/srobo/runbook/issues/58

There's a counterpart which needs to be shipped to the runbook (https://github.com/srobo/runbook/pull/64) 

I'd be interested in getting `runbook.srobo.org` (or alike) also setup, but not sure how to do that.

Unfortunately this change is rather difficult to test, but I _think_ it's right.